### PR TITLE
Saves repeated jquery selector to avoid multiple queries

### DIFF
--- a/app/assets/javascripts/ideas.js
+++ b/app/assets/javascripts/ideas.js
@@ -81,7 +81,8 @@ var Ideas = {
 
     delete: function(event) {
         var id = $(event.target).parent('li').data('id');
-        $.ajax('/ideas/'+id, { method: 'DELETE' }).success(function() { Ideas.loadAll(); })
+        $.ajax('/ideas/'+id, { method: 'DELETE' })
+            .success(function() { Ideas.loadAll(); })
     },
 
     ratingUp: function(event) {
@@ -96,6 +97,11 @@ var Ideas = {
             .success(function() { Ideas.loadAll(); })
     },
 
+    search: function(event) {
+        var query = $(event.target).val();
+        $.get('/ideas?q='+query).success(function(data) { Ideas._render(data.ideas) })
+    },
+
     convertRating: function(rating) {
         if(rating == 0) {
             return 'Swill';
@@ -104,10 +110,5 @@ var Ideas = {
         } else {
             return 'Genius';
         }
-    },
-
-    search: function(event) {
-        var query = $(event.target).val();
-        $.get('/ideas?q='+query).success(function(data) { Ideas._render(data.ideas) })
     }
 };

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,6 +13,7 @@
 <script>
   $(function() {
     var ideas = $('.ideas');
+    var search_bar = $('input[name=search]');
     $('form#createIdea').submit(Ideas.create);
     $('form#secretForm').submit(Ideas.update);
     Ideas.loadAll();
@@ -20,7 +21,7 @@
     ideas.on('click', 'button.delete', Ideas.delete);
     ideas.on('click', 'button.thumbsUp', Ideas.ratingUp);
     ideas.on('click', 'button.thumbsDown', Ideas.ratingDown);
-    $('input[name=search]').keyup(Ideas.search)
+    search_bar.keyup(Ideas.search);
   });
 </script>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,13 +12,14 @@
 
 <script>
   $(function() {
+    var ideas = $('.ideas');
     $('form#createIdea').submit(Ideas.create);
     $('form#secretForm').submit(Ideas.update);
     Ideas.loadAll();
-    $('.ideas').on('click', 'button.edit', Ideas.showForm);
-    $('.ideas').on('click', 'button.delete', Ideas.delete);
-    $('.ideas').on('click', 'button.thumbsUp', Ideas.ratingUp);
-    $('.ideas').on('click', 'button.thumbsDown', Ideas.ratingDown);
+    ideas.on('click', 'button.edit', Ideas.showForm);
+    ideas.on('click', 'button.delete', Ideas.delete);
+    ideas.on('click', 'button.thumbsUp', Ideas.ratingUp);
+    ideas.on('click', 'button.thumbsDown', Ideas.ratingDown);
     $('input[name=search]').keyup(Ideas.search)
   });
 </script>


### PR DESCRIPTION
#### This PR addresses the issue of a repeated jQuery request for the same object. Saving the lookup as a variable allows us to perform operations on the saved request instead of wasting time/memory on unnecessary lookups.
#### You should start reading it from the top!
#### You can manually test that this works by cloning down the branch and trying it out or running the test suite.

[O_O](http://i.imgur.com/CltyOLJ.gifv)

closes #1 
